### PR TITLE
Patch copy event for custom use case

### DIFF
--- a/src/components/data/columnService.ts
+++ b/src/components/data/columnService.ts
@@ -279,7 +279,7 @@ export default class ColumnService implements ColumnServiceI {
       const rgRow: RevoGrid.DataFormat[] = [];
       for (let prop of rangeProps) {
         const item = getSourceItem(store, i);
-        rgRow.push(item[prop]);
+        rgRow.push(item[prop]?.text || item[prop]);
       }
       toCopy.push(rgRow);
     }
@@ -290,7 +290,7 @@ export default class ColumnService implements ColumnServiceI {
     if (typeof val === 'undefined' || val === null) {
       return '';
     }
-    return val.toString();
+    return (val?.text || val).toString();
   }
 
   destroy() {


### PR DESCRIPTION
I store objects behind a cells instead of pure text. I render only the `text` property using a JSX template, but **copying** a cell like this yields a string `[object Object]`. With this little change I can copy the `text` property.